### PR TITLE
2 minute screensaver

### DIFF
--- a/src/components/MenuManager.py
+++ b/src/components/MenuManager.py
@@ -46,7 +46,7 @@ class MenuManager:
         self.__button_press_stack = []
         self.__continue = True
         self.__sleeping = False
-        # self.__playing_screensaver = False
+        self.__playing_screensaver = False
         self.__default_frame_sleep_time = 0.1
         self.__frame_sleep_time = self.__default_frame_sleep_time
         self.__dim_time = 30
@@ -78,6 +78,8 @@ class MenuManager:
 
     def reset(self):
         PTLogger.info("Forcing full state refresh...")
+        self.__playing_screensaver = False
+        self.__wake_oled()
         self.__miniscreen.reset()
         self.current_menu.refresh(force=True)
         self.redraw_last_image_to_display()
@@ -217,16 +219,6 @@ class MenuManager:
         except AttributeError:
             self.__frame_sleep_time = self.__default_frame_sleep_time
 
-        self.current_menu.refresh(force_refresh)
-
-        # if self.__playing_screensaver:
-        #     pass
-        # else:
-        self.__draw_current_menu_page_to_oled()
-        self.current_menu.refresh()
-        if self.current_menu.should_redraw():
-            self.__draw_current_menu_page_to_oled()
-
         time_since_last_active = perf_counter() - self.last_active_time
 
         PTLogger.debug(f"Sleep timer: {time_since_last_active}")
@@ -239,12 +231,22 @@ class MenuManager:
             self.__sleep_oled()
             return
 
-        # if time_since_last_active < self.__screensaver_time:
-            # return
+        if time_since_last_active < self.__screensaver_time:
+            return
 
-        # if not self.__playing_screensaver:
-        #     PTLogger.info("Starting screensaver...")
-        #     self.__playing_screensaver = True
+        if not self.__playing_screensaver:
+            PTLogger.info("Starting screensaver...")
+            self.__playing_screensaver = True
+
+        self.current_menu.refresh(force_refresh)
+
+        if self.__playing_screensaver:
+            pass
+        else:
+            self.__draw_current_menu_page_to_oled()
+            self.current_menu.refresh()
+            if self.current_menu.should_redraw():
+                self.__draw_current_menu_page_to_oled()
 
     def set_is_user_controlled(self, user_has_control):
         self.user_has_control = user_has_control

--- a/src/components/MenuManager.py
+++ b/src/components/MenuManager.py
@@ -216,6 +216,7 @@ class MenuManager:
 
         if button_press.event_type != ButtonPress.ButtonType.NONE:
             self.__wake_oled()
+            self.sate = MenuState.ACTIVE
             if button_press.is_direction():
                 forwards = button_press.event_type == ButtonPress.ButtonType.UP
                 self.current_menu.page_number = __get_page_no_to_move_to(
@@ -234,6 +235,11 @@ class MenuManager:
                         if self.current_menu.parent is not None:
                             self.change_menu(self.current_menu.parent)
 
+        if self.sate == MenuState.ACTIVE:
+            self.current_menu.refresh()
+            if self.current_menu.should_redraw():
+                self.__draw_current_menu_page_to_oled()
+
         try:
             max_current_hotspot_interval = self.current_menu.page.hotspot.interval
             self.__frame_sleep_time = (
@@ -251,7 +257,7 @@ class MenuManager:
         if time_since_last_active < self.timeouts[MenuState.DIM]:
             return
 
-        if self.state != MenuState.DIM:
+        if self.state == MenuState.ACTIVE:
             PTLogger.info("Going to sleep...")
             self.__sleep_oled()
             return
@@ -259,20 +265,14 @@ class MenuManager:
         if time_since_last_active < self.timeouts[MenuState.SCREENSAVER]:
             return
 
-        if self.state != MenuState.SCREENSAVER:
+        if self.state == MenuState.DIM:
             PTLogger.info("Starting screensaver...")
             self.state = MenuState.SCREENSAVER
-
-        # ------
 
         self.current_menu.refresh(force_refresh)
 
         if self.state == MenuState.SCREENSAVER:
             self.display(self.screensaver.convert("1"), wake=False)
-        else:
-            self.current_menu.refresh()
-            if self.current_menu.should_redraw():
-                self.__draw_current_menu_page_to_oled()
 
     def set_is_user_controlled(self, user_has_control):
         self.user_has_control = user_has_control

--- a/src/components/MenuManager.py
+++ b/src/components/MenuManager.py
@@ -12,6 +12,9 @@ from time import (
     sleep
 )
 
+from PIL import Image
+from components.widgets.common.functions import get_image_file_path
+
 
 class MenuManager:
     """Owner class for all Menus.
@@ -43,14 +46,18 @@ class MenuManager:
         self.__miniscreen.cancel_button.when_pressed = lambda: self.__add_button_press_to_stack(
             ButtonPress(ButtonPress.ButtonType.CANCEL))
 
+        self._screensaver = Image.open(get_image_file_path("startup/pi-top_startup.gif"))
+
         self.__button_press_stack = []
         self.__continue = True
         self.__sleeping = False
         self.__playing_screensaver = False
         self.__default_frame_sleep_time = 0.1
         self.__frame_sleep_time = self.__default_frame_sleep_time
-        self.__dim_time = 30
+        # self.__dim_time = 30
         # self.__screensaver_time = 120
+        self.__dim_time = 5
+        self.__screensaver_time = 10
 
         self.__menus = dict()
 
@@ -65,6 +72,16 @@ class MenuManager:
             self.__add_menu_to_list(Menus.PROJECTS)
             self.__add_menu_to_list(Menus.SETTINGS)
             self.change_menu(Menus.SYS_INFO)
+
+    @property
+    def screensaver(self):
+        frame_no = self._screensaver.tell()
+        try:
+            self._screensaver.seek(frame_no + 1)
+        except EOFError:
+            self._screensaver = Image.open(get_image_file_path("startup/pi-top_startup.gif"))
+
+        return self._screensaver
 
     def wait_for_user_control_release(self):
         PTLogger.info(
@@ -238,12 +255,13 @@ class MenuManager:
             PTLogger.info("Starting screensaver...")
             self.__playing_screensaver = True
 
+        # ------
+
         self.current_menu.refresh(force_refresh)
 
         if self.__playing_screensaver:
-            pass
+            self.display(self.screensaver.convert("1"))
         else:
-            self.__draw_current_menu_page_to_oled()
             self.current_menu.refresh()
             if self.current_menu.should_redraw():
                 self.__draw_current_menu_page_to_oled()

--- a/src/components/MenuManager.py
+++ b/src/components/MenuManager.py
@@ -47,8 +47,8 @@ class MenuManager:
         self.state = MenuState.ACTIVE
 
         self.timeouts = {
-            MenuState.DIM: 5,          # 30
-            MenuState.SCREENSAVER: 10  # 120
+            MenuState.DIM: 30,
+            MenuState.SCREENSAVER: 120
         }
 
         self.__miniscreen.up_button.when_pressed = lambda: self.__add_button_press_to_stack(


### PR DESCRIPTION
Closes #120

Displays ["starfield"](https://github.com/rm-hull/luma.examples/blob/master/examples/starfield.py) on repeat - this was chosen as it relatively evenly distributes the pixels that are switched on.

After unblanking, the display will ignore button presses for 0.6s to prevent accidental interaction with the menu.

Note that this, for some reason, speeds up the frame rate dramatically. It is not yet clear why, but it doesn't seem to be causing any issues, either!

Changes to the underlying menu page once it has dimmed are not currently being handled. For comparison, CPU page will not sleep, but battery page will - and disconnecting the power cable does not cause the screensaver to stop playing. This might be the desired behaviour (nothing happened on screen before sleeping, so now staying in sleep mode), but it might not be.